### PR TITLE
Fix unmapped target properties

### DIFF
--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/BaseMapperConfig.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/BaseMapperConfig.java
@@ -1,0 +1,12 @@
+package ru.ryazancev.parkingreservationsystem.util.mappers;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+
+@MapperConfig(
+        componentModel = "spring",
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        unmappedSourcePolicy = ReportingPolicy.IGNORE
+)
+public interface BaseMapperConfig {
+}

--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/CarMapper.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/CarMapper.java
@@ -4,7 +4,7 @@ import org.mapstruct.Mapper;
 import ru.ryazancev.parkingreservationsystem.models.car.Car;
 import ru.ryazancev.parkingreservationsystem.web.dto.car.CarDTO;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = BaseMapperConfig.class)
 public interface CarMapper extends Mappable<Car, CarDTO> {
 
 }

--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/PlaceMapper.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/PlaceMapper.java
@@ -4,7 +4,7 @@ import org.mapstruct.Mapper;
 import ru.ryazancev.parkingreservationsystem.models.parking.Place;
 import ru.ryazancev.parkingreservationsystem.web.dto.place.PlaceDTO;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = BaseMapperConfig.class)
 public interface PlaceMapper extends Mappable<Place, PlaceDTO> {
 
 }

--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ReservationInfoMapper.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ReservationInfoMapper.java
@@ -8,7 +8,7 @@ import ru.ryazancev.parkingreservationsystem.web.dto.reservation.ReservationInfo
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = BaseMapperConfig.class)
 public interface ReservationInfoMapper
         extends Mappable<Reservation, ReservationInfoDTO> {
 

--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ReservationMapper.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ReservationMapper.java
@@ -4,7 +4,7 @@ import org.mapstruct.Mapper;
 import ru.ryazancev.parkingreservationsystem.models.reservation.Reservation;
 import ru.ryazancev.parkingreservationsystem.web.dto.reservation.ReservationDTO;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = BaseMapperConfig.class)
 public interface ReservationMapper
         extends Mappable<Reservation, ReservationDTO> {
 

--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/UserMapper.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/UserMapper.java
@@ -4,7 +4,7 @@ import org.mapstruct.Mapper;
 import ru.ryazancev.parkingreservationsystem.models.user.User;
 import ru.ryazancev.parkingreservationsystem.web.dto.user.UserDTO;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = BaseMapperConfig.class)
 public interface UserMapper extends Mappable<User, UserDTO> {
 
 

--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ZoneInfoMapper.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ZoneInfoMapper.java
@@ -7,7 +7,7 @@ import ru.ryazancev.parkingreservationsystem.web.dto.zone.ZoneInfoDTO;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = BaseMapperConfig.class)
 public interface ZoneInfoMapper extends Mappable<Zone, ZoneInfoDTO> {
 
     @Mapping(target = "places", source = "places")

--- a/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ZoneMapper.java
+++ b/src/main/java/ru/ryazancev/parkingreservationsystem/util/mappers/ZoneMapper.java
@@ -4,7 +4,7 @@ import org.mapstruct.Mapper;
 import ru.ryazancev.parkingreservationsystem.models.parking.Zone;
 import ru.ryazancev.parkingreservationsystem.web.dto.zone.ZoneDTO;
 
-@Mapper(componentModel = "spring")
+@Mapper(config = BaseMapperConfig.class)
 public interface ZoneMapper extends Mappable<Zone, ZoneDTO> {
 
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- The focus of this PR is to update the mappers in the `util.mappers` package.
- The `@Mapper(componentModel = "spring")` annotation has been replaced with `@Mapper(config = BaseMapperConfig.class)`.
- The `BaseMapperConfig` interface has been added to provide configuration for the mappers.
- The `unmappedTargetPolicy` and `unmappedSourcePolicy` properties have been set to `ReportingPolicy.IGNORE` in the `BaseMapperConfig` interface.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->